### PR TITLE
Added separator to eslint

### DIFF
--- a/autoload/ale_silence/eslint.vim
+++ b/autoload/ale_silence/eslint.vim
@@ -1,10 +1,11 @@
 function! ale_silence#eslint#GetSilenceDirectives() abort
   return {
-        \ 'inline':   '// eslint-disable-line %s',
-        \ 'nextline': '// eslint-disable-next-line %s',
-        \ 'file':     ale#silence#Format('/* eslint %s: 0 */', ': 0, '),
-        \ 'start':    '/* eslint-disable %s */',
-        \ 'end':      '/* eslint-enable %s */'
+        \ 'inline':    '// eslint-disable-line %s',
+        \ 'nextline':  '// eslint-disable-next-line %s',
+        \ 'file':      ale#silence#Format('/* eslint %s: 0 */', ': 0, '),
+        \ 'start':     '/* eslint-disable %s */',
+        \ 'end':       '/* eslint-enable %s */',
+        \ 'separator': ','
         \}
 endfunction
 


### PR DESCRIPTION
eslint directives for multiple rules should be separated by a comma eg
```javascript
/* eslint-disable import/first,import/newline-after-import */
```